### PR TITLE
Fix export so it works w/ `module.exports` & `window`

### DIFF
--- a/src/s2geometry.js
+++ b/src/s2geometry.js
@@ -22,10 +22,14 @@
 // - i,j: they always use 30 bits, adjusting as needed. we use 0 to (1<<level)-1 instead
 //        (so GetSizeIJ for a cell is always 1)
 
-(function(exports) {
+(function(global){
 'use strict';
 
-var S2 = exports.S2 = {};
+
+var S2 = (function() {
+'use strict';
+
+var S2 = {};
 
 /*
 S2.LatLngToXYZ = function(latLng) {
@@ -484,19 +488,16 @@ S2.S2Cell.nextKey = S2.nextKey = function (key) {
   return S2.stepKey(key, 1);
 };
 
-})('undefined' !== typeof window ? window : module.exports);
+return S2;
+})();
 
-(function (exports) {
-'use strict';
+var L = (function () {
+  'use strict';
 
   // Adapted from Leafletjs https://searchcode.com/codesearch/view/42525008/
 
   var L = {};
-  var S2 = exports.S2;
 
-  if (!exports.L) {
-    exports.L = L;
-  }
   S2.L = L;
 
   L.LatLng = function (/*Number*/ rawLat, /*Number*/ rawLng, /*Boolean*/ noWrap) {
@@ -517,4 +518,18 @@ S2.S2Cell.nextKey = S2.nextKey = function (key) {
 
   L.LatLng.DEG_TO_RAD = Math.PI / 180;
   L.LatLng.RAD_TO_DEG = 180 / Math.PI;
-})('undefined' !== typeof window ? window : module.exports);
+  
+  return L;
+})();
+
+// export to module.exports or window
+if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+  module.exports.S2 = S2;
+  module.exports.L = L;
+}
+else {
+  global.S2 = S2;
+  global.L = L;
+}
+
+})(this);


### PR DESCRIPTION
Fixes Issue #13.

This also fixes a similar issue where this library is used via browserify/webpack in the browser (or other environments where `window` is defined). Previously, `var S2 = require("s1-geometry").S2;`, would result in `window.S2` being defined but `S2` remaining undefined. This changes the behavior to prefer exporting via `module.exports`, if available, and falling back to `window` (or whatever `this` is in the module's imported scope --  which is usually `window`). Additionally, this keeps the library from polluting the global scope unnecessarily.
